### PR TITLE
feat: LJM Streaming 

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+[target.armv7-unknown-linux-gnueabihf]
+linker = "./zcc"
+
+[profile.release]
+strip = true
+lto = true

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 ./*.sh
 ./build.sh
 ./load.sh
+/build.sh
+/load.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /target
 /.idea
 ./*.sh
-zcc
-./zcc
+./build.sh
+./load.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 /.idea
+./*.sh
+zcc
+./zcc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ libloading = "0.8"
 serde = { version = "1.0.192", features = ["std", "derive"], optional = true }
 
 [features]
-default = []
+stream = []
+default = ["stream"]
 
 [lib]
 name = "ljmrs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,6 @@ description = "LabJack LJM Bindings for Rust"
 license = "MIT"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 libloading = "0.8"
 serde = { version = "1.0.192", features = ["std", "derive"], optional = true }

--- a/examples/config.rs
+++ b/examples/config.rs
@@ -1,12 +1,8 @@
 extern crate ljmrs;
 
-use std::time::Instant;
-
 use ljmrs::LJMWrapper;
 
 fn read() {
-    let now = Instant::now();
-
     let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
 
     let open_call = ljm_wrapper
@@ -19,32 +15,23 @@ fn read() {
 
     println!("Opened LabJack, got handle: {}", open_call);
 
-    let elapsed = now.elapsed();
-    println!("Elapsed: {:.2?}", elapsed);
-
-    let now = Instant::now();
-
     let read_value = ljm_wrapper
-        .read_name(open_call, "TEST_INT32".to_string())
+        .get_config("LJM_STREAM_SCANS_RETURN".to_string())
         .expect("Expected Value");
-    println!("Got: {}", read_value);
 
-    let elapsed = now.elapsed();
-    println!("Elapsed: {:.2?}", elapsed);
+    println!("Got configuration value: {}", read_value);
 
     ljm_wrapper
-        .write_name(open_call, "TEST_INT32".to_string(), 15)
+        .set_config("LJM_STREAM_SCANS_RETURN".to_string(), 2)
         .expect("Expected Value");
 
-    let now = Instant::now();
+    println!("Set config value to 2, reading...");
 
     let read_value = ljm_wrapper
-        .read_name(open_call, "TEST_INT32".to_string())
+        .get_config("LJM_STREAM_SCANS_RETURN".to_string())
         .expect("Expected Value");
-    println!("Got: {}", read_value);
 
-    let elapsed = now.elapsed();
-    println!("Elapsed: {:.2?}", elapsed);
+    println!("Got new configuration value: {}", read_value);
 }
 
 fn main() {

--- a/examples/direct.rs
+++ b/examples/direct.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use ljmrs::LJMWrapper;
 
 fn stream() {
-    let mut ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
 
     let open_call = ljm_wrapper
         .open_jack(
@@ -28,7 +28,6 @@ fn stream() {
             .read_name(open_call, "AIN1".to_string())
             .expect("");
 
-        // thread::sleep(Duration::from_millis(1));
         i += 1;
     }
 

--- a/examples/direct.rs
+++ b/examples/direct.rs
@@ -1,0 +1,37 @@
+extern crate ljmrs;
+
+use std::time::Instant;
+
+use ljmrs::LJMWrapper;
+
+fn stream() {
+    let mut ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+
+    let open_call = ljm_wrapper
+        .open_jack(
+            ljmrs::DeviceType::ANY,
+            ljmrs::ConnectionType::ANY,
+            "ANY".to_string(),
+        )
+        .expect("Could not open DEMO LabJack");
+
+    println!("Opened LabJack, got handle: {}", open_call);
+
+    let now = Instant::now();
+
+    let mut i = 0;
+    while i < 50 {
+        ljm_wrapper.read_name(open_call, "AIN0".to_string()).expect("");
+        ljm_wrapper.read_name(open_call, "AIN1".to_string()).expect("");
+
+        // thread::sleep(Duration::from_millis(1));
+        i += 1;
+    }
+
+    let elapsed = now.elapsed();
+    println!("Elapsed: {:.2?}", elapsed);
+}
+
+fn main() {
+    stream();
+}

--- a/examples/direct.rs
+++ b/examples/direct.rs
@@ -21,8 +21,12 @@ fn stream() {
 
     let mut i = 0;
     while i < 50 {
-        ljm_wrapper.read_name(open_call, "AIN0".to_string()).expect("");
-        ljm_wrapper.read_name(open_call, "AIN1".to_string()).expect("");
+        ljm_wrapper
+            .read_name(open_call, "AIN0".to_string())
+            .expect("");
+        ljm_wrapper
+            .read_name(open_call, "AIN1".to_string())
+            .expect("");
 
         // thread::sleep(Duration::from_millis(1));
         i += 1;

--- a/examples/load.rs
+++ b/examples/load.rs
@@ -1,7 +1,8 @@
 extern crate ljmrs;
 
-use ljmrs::LJMWrapper;
 use std::time::Instant;
+
+use ljmrs::LJMWrapper;
 
 fn load() {
     let now = Instant::now();
@@ -23,10 +24,12 @@ fn load() {
 
     let now = Instant::now();
 
+    let name: &str = "FIO0";
+
     let (addr, typ) = ljm_wrapper
-        .name_to_address("TEST_INT32")
+        .name_to_address(name)
         .expect("Expected NTA");
-    println!("TEST_INT32 => Address: {}, Type: {}", addr, typ);
+    println!("{name} => Address: {}, Type: {}", addr, typ);
 
     let elapsed = now.elapsed();
     println!("Elapsed: {:.2?}", elapsed);

--- a/examples/load.rs
+++ b/examples/load.rs
@@ -24,7 +24,7 @@ fn load() {
     let now = Instant::now();
 
     let (addr, typ) = ljm_wrapper
-        .name_to_address("TEST_INT32".to_string())
+        .name_to_address("TEST_INT32")
         .expect("Expected NTA");
     println!("TEST_INT32 => Address: {}, Type: {}", addr, typ);
 

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -1,6 +1,6 @@
 extern crate ljmrs;
 
-use ljmrs::{LJMError, LJMWrapper};
+use ljmrs::LJMWrapper;
 
 fn stream() {
     let mut ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -1,0 +1,39 @@
+extern crate ljmrs;
+
+use ljmrs::LJMWrapper;
+
+fn stream() {
+    let mut ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+
+    let open_call = ljm_wrapper
+        .open_jack(
+            ljmrs::DeviceType::ANY,
+            ljmrs::ConnectionType::ANY,
+            "-2".to_string(),
+        )
+        .expect("Could not open DEMO LabJack");
+
+    println!("Opened LabJack, got handle: {}", open_call);
+
+    let streams = vec!["AIN0", "AIN1"];
+
+    ljm_wrapper
+        .stream_start(open_call, 1, 1000.0, streams)
+        .expect("Could not start stream");
+
+    assert!(ljm_wrapper.is_stream_active());
+
+    let read_value = ljm_wrapper
+        .stream_read(open_call)
+        .expect("Could not read values");
+
+    println!("Got: {:?}", read_value);
+
+    ljm_wrapper.stream_stop(open_call).expect("Expected Value");
+
+    assert!(!ljm_wrapper.is_stream_active());
+}
+
+fn main() {
+    stream();
+}

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -1,6 +1,6 @@
 extern crate ljmrs;
 
-use ljmrs::LJMWrapper;
+use ljmrs::{LJMError, LJMWrapper};
 
 fn stream() {
     let mut ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
@@ -19,7 +19,7 @@ fn stream() {
 
     ljm_wrapper
         .stream_start(open_call, 1, 1000.0, streams)
-        .expect("Could not start stream");
+        .expect("Failed to start stream");
 
     assert!(ljm_wrapper.is_stream_active());
 

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -17,6 +17,9 @@ fn stream() {
 
     let streams = vec!["AIN0", "AIN1"];
 
+    // Do note that this examples will fail on
+    // DEMO mode labjacks, as currently stream mode
+    // is not supported for them.
     ljm_wrapper
         .stream_start(open_call, 1, 1000.0, streams)
         .expect("Failed to start stream");

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -37,7 +37,7 @@ fn stream() {
             .expect("Could not read values");
 
         println!("Got {}: {:?}", read_value.len(), read_value);
-        
+
         // thread::sleep(Duration::from_millis(1));
         i += 1;
     }

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -1,5 +1,7 @@
 extern crate ljmrs;
 
+use std::time::Instant;
+
 use ljmrs::LJMWrapper;
 
 fn stream() {
@@ -9,28 +11,39 @@ fn stream() {
         .open_jack(
             ljmrs::DeviceType::ANY,
             ljmrs::ConnectionType::ANY,
-            "-2".to_string(),
+            "ANY".to_string(),
         )
         .expect("Could not open DEMO LabJack");
 
     println!("Opened LabJack, got handle: {}", open_call);
 
-    let streams = vec!["AIN0", "AIN1"];
+    let streams = vec!["AIN0"];
 
     // Do note that this examples will fail on
     // DEMO mode labjacks, as currently stream mode
     // is not supported for them.
     ljm_wrapper
-        .stream_start(open_call, 1, 1000.0, streams)
+        .stream_start(open_call, 2, 50_000.0, streams)
         .expect("Failed to start stream");
 
     assert!(ljm_wrapper.is_stream_active());
 
-    let read_value = ljm_wrapper
-        .stream_read(open_call)
-        .expect("Could not read values");
+    let now = Instant::now();
 
-    println!("Got: {:?}", read_value);
+    let mut i = 0;
+    while i < 50 {
+        let read_value = ljm_wrapper
+            .stream_read(open_call)
+            .expect("Could not read values");
+
+        println!("Got {}: {:?}", read_value.len(), read_value);
+        
+        // thread::sleep(Duration::from_millis(1));
+        i += 1;
+    }
+
+    let elapsed = now.elapsed();
+    println!("Elapsed: {:.2?}", elapsed);
 
     ljm_wrapper.stream_stop(open_call).expect("Expected Value");
 

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -1,0 +1,52 @@
+extern crate ljmrs;
+
+use std::time::Instant;
+
+use ljmrs::LJMWrapper;
+
+fn read() {
+    let now = Instant::now();
+
+    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+
+    let open_call = ljm_wrapper
+        .open_jack(
+            ljmrs::DeviceType::ANY,
+            ljmrs::ConnectionType::ANY,
+            "-1".to_string(),
+        )
+        .expect("Could not open DEMO LabJack");
+
+    println!("Opened LabJack, got handle: {}", open_call);
+
+    let elapsed = now.elapsed();
+    println!("Elapsed: {:.2?}", elapsed);
+
+    let now = Instant::now();
+
+    let read_value = ljm_wrapper
+        .read_name(open_call, "TEST_INT32".to_string())
+        .expect("Expected Value");
+    println!("Got: {}", read_value);
+
+    let elapsed = now.elapsed();
+    println!("Elapsed: {:.2?}", elapsed);
+
+    ljm_wrapper
+        .write_name(open_call, "TEST_INT32".to_string(), 15)
+        .expect("Expected Value");
+
+    let now = Instant::now();
+
+    let read_value = ljm_wrapper
+        .read_name(open_call, "TEST_INT32".to_string())
+        .expect("Expected Value");
+    println!("Got: {}", read_value);
+
+    let elapsed = now.elapsed();
+    println!("Elapsed: {:.2?}", elapsed);
+}
+
+fn main() {
+    read();
+}

--- a/src/ljm/error.rs
+++ b/src/ljm/error.rs
@@ -1,0 +1,90 @@
+use std::fmt::Debug;
+
+/// Taken from: [LJM ErrorCodes](https://labjack.com/pages/support?doc=%2Fsoftware-driver%2Fljm-users-guide%2Ferror-codes%2F)
+///
+/// > Note:
+/// > We ignore the 0 value as NoError, as
+/// > we replace it with a rust Result type.
+pub enum LJMErrorCode {
+    LJMWarning(i32),      // 200-399
+    LJMModbusError(i32),  // 1200-1216
+    LJMLibraryError(i32), // 1220-1399
+    DeviceError(i32),     // 2000-2999
+    UserError(i32),       // 3900-3999
+    Unknown(i32),         // For any values outside these ranges.
+}
+
+impl From<&LJMErrorCode> for i32 {
+    fn from(value: &LJMErrorCode) -> Self {
+        match value {
+            LJMErrorCode::LJMWarning(error_code) => error_code + 200,
+            LJMErrorCode::LJMModbusError(error_code) => error_code + 1200,
+            LJMErrorCode::LJMLibraryError(error_code) => error_code + 1220,
+            LJMErrorCode::DeviceError(error_code) => error_code + 2000,
+            LJMErrorCode::UserError(error_code) => error_code + 3900,
+            LJMErrorCode::Unknown(error_code) => *error_code,
+        }
+    }
+}
+
+impl From<i32> for LJMErrorCode {
+    fn from(error_code: i32) -> Self {
+        match error_code {
+            200..=399 => LJMErrorCode::LJMWarning(error_code - 200),
+            1200..=1216 => LJMErrorCode::LJMModbusError(error_code - 1200),
+            1220..=1399 => LJMErrorCode::LJMLibraryError(error_code - 1220),
+            2000..=2999 => LJMErrorCode::DeviceError(error_code - 2000),
+            3900..=3999 => LJMErrorCode::UserError(error_code - 3900),
+            _ => LJMErrorCode::Unknown(error_code),
+        }
+    }
+}
+
+impl Debug for LJMErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let code: i32 = self.into();
+
+        let name = match self {
+            LJMErrorCode::LJMWarning(_) => "LabJackWarning",
+            LJMErrorCode::LJMModbusError(_) => "ModbusError",
+            LJMErrorCode::LJMLibraryError(_) => "LibraryError",
+            LJMErrorCode::DeviceError(_) => "DeviceError",
+            LJMErrorCode::UserError(_) => "UserError",
+            LJMErrorCode::Unknown(_) => "UnknownError",
+        };
+
+        write!(f, "{}({})", name, code)
+    }
+}
+
+pub enum LJMError {
+    StartupError(libloading::Error),
+    ErrorCode(LJMErrorCode, String),
+    LibraryError(String),
+    LibloadingError(libloading::Error),
+    Uninitialized,
+    StreamNotStarted,
+}
+
+impl From<libloading::Error> for LJMError {
+    fn from(value: libloading::Error) -> Self {
+        LJMError::LibloadingError(value)
+    }
+}
+
+impl Debug for LJMError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                LJMError::ErrorCode(error, value) => format!("LJMError::{:?} ({})", error, value),
+                LJMError::StartupError(error) => format!("StartupError::{:?}", error),
+                LJMError::LibloadingError(error) => format!("LibraryLoadingError::{:?}", error),
+                LJMError::LibraryError(error) => format!("LibraryError::{:?}", error),
+                LJMError::Uninitialized => "UninitializedError".to_string(),
+                LJMError::StreamNotStarted => "StreamNotStartedError".to_string(),
+            }
+        )
+    }
+}

--- a/src/ljm/error.rs
+++ b/src/ljm/error.rs
@@ -5,12 +5,18 @@ use std::fmt::Debug;
 /// > Note:
 /// > We ignore the 0 value as NoError, as
 /// > we replace it with a rust Result type.
+#[derive(PartialOrd, PartialEq)]
 pub enum LJMErrorCode {
-    LJMWarning(i32),      // 200-399
-    LJMModbusError(i32),  // 1200-1216
-    LJMLibraryError(i32), // 1220-1399
-    DeviceError(i32),     // 2000-2999
-    UserError(i32),       // 3900-3999
+    LJMWarning(i32),
+    // 200-399
+    LJMModbusError(i32),
+    // 1200-1216
+    LJMLibraryError(i32),
+    // 1220-1399
+    DeviceError(i32),
+    // 2000-2999
+    UserError(i32),
+    // 3900-3999
     Unknown(i32),         // For any values outside these ranges.
 }
 

--- a/src/ljm/handle.rs
+++ b/src/ljm/handle.rs
@@ -58,13 +58,10 @@ pub struct DeviceHandleInfo {
 
 impl Display for DeviceHandleInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        // DT on CT @ ...B/MB
-        // 000.000.000:0000
-        // SERIAL_NUMBER
-
+        // DT on CT @ ...B/MB 000.000.000:0000 => SERIAL_NUMBER
         write!(
             f,
-            "{} on {} @ {}B/MB\n{}:{} => {}",
+            "{} on {} @ {}B/MB {}:{} => {}",
             self.device_type,
             self.connection_type,
             self.max_bytes_per_megabyte,
@@ -102,7 +99,7 @@ impl Display for ConnectionType {
             ConnectionType::ETHERNET => "ETHERNET",
             ConnectionType::ANY | ConnectionType::UNKNOWN(_) => "ANY",
         }
-        .to_string();
+            .to_string();
         write!(f, "{}", str)
     }
 }

--- a/src/ljm/mod.rs
+++ b/src/ljm/mod.rs
@@ -1,5 +1,7 @@
+pub mod error;
 pub mod handle;
 pub mod wrapper;
 
+pub use error::*;
 pub use handle::*;
 pub use wrapper::*;

--- a/src/ljm/wrapper.rs
+++ b/src/ljm/wrapper.rs
@@ -342,6 +342,7 @@ impl LJMWrapper {
     /// Starts a LJM Stream, stopped with `stream_stop`.
     /// Returns actual device scan rate (chosen by LabJack)
     #[doc(alias = "LJM_eStreamStart")]
+    #[cfg(feature = "stream")]
     pub fn stream_start<T>(
         &mut self,
         handle: i32,
@@ -388,6 +389,7 @@ impl LJMWrapper {
 
     /// Stops an LJM Stream started with `stream_start`
     #[doc(alias = "LJM_eStreamStop")]
+    #[cfg(feature = "stream")]
     pub fn stream_stop(&self, handle: i32) -> Result<(), LJMError> {
         let stream_stop: Symbol<extern "C" fn(i32) -> i32> =
             unsafe { self.get_c_function(b"LJM_eStreamStop")? };
@@ -398,11 +400,9 @@ impl LJMWrapper {
 
     /// Stops an LJM Stream started with `stream_start`
     #[doc(alias = "LJM_eStreamRead")]
+    #[cfg(feature = "stream")]
     pub fn stream_read(&self, handle: i32) -> Result<(), LJMError> {
-        let stream_value = self
-            .stream
-            .clone()
-            .map_or(Err(LJMError::StreamNotStarted), |v| Ok(v))?;
+        let stream_value = self.stream.clone().ok_or(LJMError::StreamNotStarted)?;
 
         let stream_stop: Symbol<extern "C" fn(i32, *mut f64, *mut i32, *mut i32) -> i32> =
             unsafe { self.get_c_function(b"LJM_eStreamRead")? };
@@ -421,6 +421,12 @@ impl LJMWrapper {
             &mut dev_scan_backlog,
             &mut ljm_scan_backlog,
         );
+
         LJMWrapper::error_code((), error_code)
+    }
+
+    #[cfg(feature = "stream")]
+    pub fn is_stream_active(&self) -> bool {
+        self.stream.is_some()
     }
 }

--- a/src/ljm/wrapper.rs
+++ b/src/ljm/wrapper.rs
@@ -1,5 +1,6 @@
 use std::{
     ffi::{c_char, c_uint, CString},
+    fmt::Display,
     os::raw::c_double,
 };
 
@@ -151,7 +152,10 @@ impl LJMWrapper {
     /// Returns a tuple of (address, type) in (i32, i32) format.
     /// Verifiable with: - [LabJack Modbus Map](https://labjack.com/pages/support/?doc=/datasheets/t-series-datasheet/31-modbus-map-t-series-datasheet/)
     #[doc(alias = "LJM_NameToAddress")]
-    pub fn name_to_address(&self, identifier: &str) -> Result<(i32, i32), LJMError> {
+    pub fn name_to_address<T>(&self, identifier: T) -> Result<(i32, i32), LJMError>
+    where
+        T: ToString,
+    {
         let n_to_addr: Symbol<extern "C" fn(*const c_char, *mut i32, *mut i32) -> i32> =
             unsafe { self.get_c_function(b"LJM_NameToAddress")? };
 
@@ -320,13 +324,16 @@ impl LJMWrapper {
 
     /// Returns actual device scan rate (chosen by LabJack)
     #[doc(alias = "LJM_eStreamStart")]
-    pub fn stream_start(
+    pub fn stream_start<T>(
         &self,
         handle: i32,
         scans_per_read: i32,
         suggested_scan_rate: f64,
-        streams: Vec<String>,
-    ) -> Result<f64, LJMError> {
+        streams: Vec<T>,
+    ) -> Result<f64, LJMError>
+    where
+        T: ToString + Display,
+    {
         let stream_start: Symbol<extern "C" fn(i32, i32, i32, *const i32, *mut c_double) -> i32> =
             unsafe { self.get_c_function(b"LJM_eStreamStart")? };
 

--- a/src/ljm/wrapper.rs
+++ b/src/ljm/wrapper.rs
@@ -3,6 +3,7 @@ use std::{
     fmt::Display,
     os::raw::c_double,
 };
+use std::fmt::{Debug, Formatter};
 
 use libloading::{Library, Symbol};
 #[cfg(feature = "serde")]
@@ -31,14 +32,20 @@ pub struct LJMWrapper {
     stream: Option<LJMStream>,
 }
 
+impl Debug for LJMWrapper {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LJMWrapper")
+    }
+}
+
 // We always return a dummy wrapper (uninitialized library)
 // When being deserialized, as there is no way to correctly serialize
 // The wrapper.
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for LJMWrapper {
     fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
+        where
+            D: Deserializer<'de>,
     {
         Ok(LJMWrapper::dummy())
     }
@@ -149,8 +156,8 @@ impl LJMWrapper {
     /// Verifiable with: - [LabJack Modbus Map](https://labjack.com/pages/support/?doc=/datasheets/t-series-datasheet/31-modbus-map-t-series-datasheet/)
     #[doc(alias = "LJM_NameToAddress")]
     pub fn name_to_address<T>(&self, identifier: T) -> Result<(i32, i32), LJMError>
-    where
-        T: ToString,
+        where
+            T: ToString,
     {
         let n_to_addr: Symbol<extern "C" fn(*const c_char, *mut i32, *mut i32) -> i32> =
             unsafe { self.get_c_function(b"LJM_NameToAddress")? };
@@ -332,8 +339,8 @@ impl LJMWrapper {
         suggested_scan_rate: f64,
         streams: Vec<T>,
     ) -> Result<f64, LJMError>
-    where
-        T: ToString + Display,
+        where
+            T: ToString + Display,
     {
         let stream_start: Symbol<extern "C" fn(i32, i32, i32, *const i32, *mut c_double) -> i32> =
             unsafe { self.get_c_function(b"LJM_eStreamStart")? };

--- a/src/ljm/wrapper.rs
+++ b/src/ljm/wrapper.rs
@@ -341,6 +341,9 @@ impl LJMWrapper {
 
     /// Starts a LJM Stream, stopped with `stream_stop`.
     /// Returns actual device scan rate (chosen by LabJack)
+    ///
+    /// `suggested_scan_rate` The scan rate forwarded to LJM which it will attempt to use
+    ///
     #[doc(alias = "LJM_eStreamStart")]
     #[cfg(feature = "stream")]
     pub fn stream_start<T>(
@@ -401,7 +404,7 @@ impl LJMWrapper {
     /// Stops an LJM Stream started with `stream_start`
     #[doc(alias = "LJM_eStreamRead")]
     #[cfg(feature = "stream")]
-    pub fn stream_read(&self, handle: i32) -> Result<(), LJMError> {
+    pub fn stream_read(&self, handle: i32) -> Result<Vec<f64>, LJMError> {
         let stream_value = self.stream.clone().ok_or(LJMError::StreamNotStarted)?;
 
         let stream_stop: Symbol<extern "C" fn(i32, *mut f64, *mut i32, *mut i32) -> i32> =
@@ -422,7 +425,7 @@ impl LJMWrapper {
             &mut ljm_scan_backlog,
         );
 
-        LJMWrapper::error_code((), error_code)
+        LJMWrapper::error_code(addr_slice, error_code)
     }
 
     #[cfg(feature = "stream")]

--- a/src/ljm/wrapper.rs
+++ b/src/ljm/wrapper.rs
@@ -442,23 +442,6 @@ impl LJMWrapper {
         self.error_code(addr_slice, error_code)
     }
 
-    // /// Handles the LJM callback for a stream
-    // #[doc(alias = "LJM_StreamSetCallback")]
-    // #[cfg(feature = "stream")]
-    // pub fn stream_set_callback(
-    //     &self,
-    //     handle_id: i32,
-    //     function: extern "C" fn(*mut i32),
-    // ) -> Result<Vec<f64>, LJMError> {
-    //     let stream_value = self.stream.clone().ok_or(LJMError::StreamNotStarted)?;
-
-    //     let stream_stop: Symbol<extern "C" fn(i32, *mut f64, *mut i32, *mut i32) -> i32> =
-    //         unsafe { self.get_c_function(b"LJM_SetStreamCallback")? };
-
-    //     // ...
-    //     Ok(vec![])
-    // }
-
     #[cfg(feature = "stream")]
     pub fn is_stream_active(&self) -> bool {
         self.stream.is_some()

--- a/src/ljm/wrapper.rs
+++ b/src/ljm/wrapper.rs
@@ -1,9 +1,9 @@
-use std::fmt::{Debug, Formatter};
 use std::{
     ffi::{c_char, c_uint, CString},
     fmt::Display,
     os::raw::c_double,
 };
+use std::fmt::{Debug, Formatter};
 
 use libloading::{Library, Symbol};
 #[cfg(feature = "serde")]
@@ -44,8 +44,8 @@ impl Debug for LJMWrapper {
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for LJMWrapper {
     fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
+        where
+            D: Deserializer<'de>,
     {
         Ok(LJMWrapper::dummy())
     }
@@ -54,8 +54,8 @@ impl<'de> Deserialize<'de> for LJMWrapper {
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for &'static LJMWrapper {
     fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
+        where
+            D: Deserializer<'de>,
     {
         Ok(&LJM_DUMMY)
     }
@@ -64,8 +64,8 @@ impl<'de> Deserialize<'de> for &'static LJMWrapper {
 #[cfg(feature = "serde")]
 impl Serialize for &'static LJMWrapper {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
+        where
+            S: Serializer,
     {
         serializer.serialize_unit()
     }
@@ -182,8 +182,8 @@ impl LJMWrapper {
     /// Verifiable with: - [LabJack Modbus Map](https://labjack.com/pages/support/?doc=/datasheets/t-series-datasheet/31-modbus-map-t-series-datasheet/)
     #[doc(alias = "LJM_NameToAddress")]
     pub fn name_to_address<T>(&self, identifier: T) -> Result<(i32, i32), LJMError>
-    where
-        T: ToString,
+        where
+            T: ToString,
     {
         let n_to_addr: Symbol<extern "C" fn(*const c_char, *mut i32, *mut i32) -> i32> =
             unsafe { self.get_c_function(b"LJM_NameToAddress")? };
@@ -365,8 +365,8 @@ impl LJMWrapper {
         suggested_scan_rate: f64,
         streams: Vec<T>,
     ) -> Result<f64, LJMError>
-    where
-        T: ToString + Display,
+        where
+            T: ToString + Display,
     {
         let stream_start: Symbol<extern "C" fn(i32, i32, i32, *const i32, *mut c_double) -> i32> =
             unsafe { self.get_c_function(b"LJM_eStreamStart")? };
@@ -428,9 +428,9 @@ impl LJMWrapper {
         let mut ljm_scan_backlog: i32 = 0;
 
         // Length = ScansPerRead * NumberOfAddresses
-        let scan_length = stream_value.scan_rate * stream_value.scan_list.len() as f64;
+        let scan_length = stream_value.scan_rate as usize * stream_value.scan_list.len();
 
-        let mut addr_slice = vec![0.0, scan_length];
+        let mut addr_slice = vec![0.0; scan_length];
 
         let error_code = stream_stop(
             handle,

--- a/src/ljm/wrapper.rs
+++ b/src/ljm/wrapper.rs
@@ -372,11 +372,13 @@ impl LJMWrapper {
     /// Stops an LJM Stream started with `stream_start`
     #[doc(alias = "LJM_eStreamStop")]
     #[cfg(feature = "stream")]
-    pub fn stream_stop(&self, handle: i32) -> Result<(), LJMError> {
+    pub fn stream_stop(&mut self, handle: i32) -> Result<(), LJMError> {
         let stream_stop: Symbol<extern "C" fn(i32) -> i32> =
             unsafe { self.get_c_function(b"LJM_eStreamStop")? };
 
         let error_code = stream_stop(handle);
+
+        self.stream = None;
         self.error_code((), error_code)
     }
 

--- a/src/ljm/wrapper.rs
+++ b/src/ljm/wrapper.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Deserializer};
 
 use crate::{
     ljm::handle::{ConnectionType, DeviceHandleInfo, DeviceType},
-    LJMError, LJMErrorCode,
+    LJMError,
 };
 
 static LJM_DUMMY: LJMWrapper = LJMWrapper::dummy();

--- a/tests/mem.rs
+++ b/tests/mem.rs
@@ -13,6 +13,21 @@ fn assert_error(error: LJMError, error_code: i32) {
 }
 
 #[test]
+fn bad_open() {
+    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+
+    // Forge a fake handle
+    let handle: i32 = -1;
+    let result = ljm_wrapper.read_name(handle, "AIN0".to_string());
+
+    assert!(result.is_err());
+
+    let error: LJMError = result.err().unwrap();
+
+    assert_error(error, 1224);
+}
+
+#[test]
 fn fake_write() {
     let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
 

--- a/tests/mem.rs
+++ b/tests/mem.rs
@@ -1,0 +1,49 @@
+use ljmrs;
+use ljmrs::{LJMError, LJMErrorCode, LJMWrapper};
+
+fn assert_error(error: LJMError, error_code: i32) {
+    assert!(
+        matches!(
+            error,
+            LJMError::ErrorCode(
+               i, _j
+            ) if i == LJMErrorCode::from(error_code)
+        )
+    );
+}
+
+#[test]
+fn fake_write() {
+    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+
+    // Forge a fake handle
+    let handle: i32 = -1;
+
+    // Forge a pin num. AIN2 with a _RANGE property
+    let modbus_range = format!("{}_RANGE", "AIN2");
+
+    let result = ljm_wrapper.write_name(handle, modbus_range, 0);
+
+    assert!(result.is_err());
+
+    let error: LJMError = result.err().unwrap();
+
+    assert_error(error, 1224);
+}
+
+#[test]
+fn use_after_write() {
+    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+
+    // Forge a fake handle
+    let handle: i32 = -1;
+
+    // Forge a pin num. AIN2 with a _RANGE property
+    let modbus_range = format!("{}_RANGE", "AIN2");
+
+    let result = ljm_wrapper.write_name(handle, modbus_range, 0);
+
+    assert!(result.is_err());
+    let error: LJMError = result.err().unwrap();
+    assert_error(error, 1224);
+}

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -1,0 +1,42 @@
+use ljmrs;
+use ljmrs::{LJMError, LJMErrorCode, LJMWrapper};
+
+fn assert_error(error: LJMError, error_code: i32) {
+    assert!(
+        matches!(
+            error,
+            LJMError::ErrorCode(
+               i, _j
+            ) if i == LJMErrorCode::from(error_code)
+        )
+    );
+}
+
+#[test]
+fn standard_open_read() {
+    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+
+    let open_call = ljm_wrapper
+        .open_jack(
+            ljmrs::DeviceType::ANY,
+            ljmrs::ConnectionType::ANY,
+            "-2".to_string(),
+        )
+        .expect("Could not open DEMO LabJack");
+
+    println!("Opened LabJack, got handle: {}", open_call);
+
+    let read_value = ljm_wrapper
+        .read_name(open_call, "TEST_INT32".to_string())
+        .expect("Expected Value");
+    println!("Got: {}", read_value);
+
+    ljm_wrapper
+        .write_name(open_call, "TEST_INT32".to_string(), 15)
+        .expect("Expected Value");
+
+    let read_value = ljm_wrapper
+        .read_name(open_call, "TEST_INT32".to_string())
+        .expect("Expected Value");
+    println!("Got: {}", read_value);
+}

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use ljmrs;
 use ljmrs::{LJMError, LJMErrorCode, LJMWrapper};
 
@@ -13,6 +15,40 @@ fn assert_error(error: LJMError, error_code: i32) {
 }
 
 #[test]
+fn open() {
+    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+
+    let open_call = ljm_wrapper
+        .open_jack(
+            ljmrs::DeviceType::ANY,
+            ljmrs::ConnectionType::ANY,
+            "-2".to_string(),
+        );
+
+    assert!(open_call.is_ok());
+}
+
+#[test]
+fn get_name() {
+    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+
+    let mut elapsed_times: Vec<f32> = vec![];
+    let addresses = vec!["AIN0", "AIN1", "AIN2", "AIN3", "FIO0", "FIO1"];
+
+    for _ in 0..addresses.len() {
+        let now = Instant::now();
+        let result = ljm_wrapper.name_to_address("AIN0".to_string());
+        assert!(result.is_ok());
+
+        let elapsed = now.elapsed().as_millis();
+        elapsed_times.push(elapsed as f32)
+    }
+
+    let avg: f32 = elapsed_times.iter().sum::<f32>() / addresses.len() as f32;
+    assert!(avg < 5.0f32, "Average time elapsed: {}. Computes: {:?}", avg, elapsed_times);
+}
+
+#[test]
 fn standard_open_read() {
     let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
 
@@ -24,19 +60,11 @@ fn standard_open_read() {
         )
         .expect("Could not open DEMO LabJack");
 
-    println!("Opened LabJack, got handle: {}", open_call);
+    assert_ne!(open_call, -1);
 
     let read_value = ljm_wrapper
         .read_name(open_call, "TEST_INT32".to_string())
         .expect("Expected Value");
-    println!("Got: {}", read_value);
 
-    ljm_wrapper
-        .write_name(open_call, "TEST_INT32".to_string(), 15)
-        .expect("Expected Value");
-
-    let read_value = ljm_wrapper
-        .read_name(open_call, "TEST_INT32".to_string())
-        .expect("Expected Value");
-    println!("Got: {}", read_value);
+    assert_eq!(read_value, 0f64);
 }


### PR DESCRIPTION
#### New Functions
- `stream_start(handle, scans, rate, streams)` Function
- `stream_stop(handle)` Function
- `stream_read(handle)` Function
- `error_to_string(code)`
- `set_config(cfg, val)`
- `get_config(cfg)`

#### Changes
- Added `stream` Flag
- Added `config` Example
- Added `direct` Example
- Added `stream` Example
- Modified/Moved Other Examples
- Added `LJMStream`
- Added Memory Tests
- Added Test Template