### PR TITLE
feat: Lua Modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,58 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "backtrace"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "cc"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "libc"
+version = "0.2.155"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
@@ -24,7 +72,38 @@ version = "0.1.2"
 dependencies = [
  "libloading",
  "serde",
+ "tokio",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "object"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "proc-macro2"
@@ -43,6 +122,12 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "serde"
@@ -73,6 +158,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tokio"
+version = "1.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+dependencies = [
+ "backtrace",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "ljmrs"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "libloading",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { version = "1.32.0", features = ["time", "rt-multi-thread", "macros"], 
 stream = []
 lua = []
 tokio = ["dep:tokio"]
-default = ["stream", "lua"]
+default = ["stream"]
 
 [lib]
 name = "ljmrs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,13 @@ edition = "2021"
 [dependencies]
 libloading = "0.8"
 serde = { version = "1.0.192", features = ["std", "derive"], optional = true }
+tokio = { version = "1.32.0", features = ["time", "rt-multi-thread", "macros"], optional = true }
 
 [features]
 stream = []
-default = ["stream"]
+lua = []
+tokio = ["dep:tokio"]
+default = ["stream", "lua"]
 
 [lib]
 name = "ljmrs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ljmrs"
-version = "0.1.2"
+version = "0.2.0"
 description = "LabJack LJM Bindings for Rust"
 license = "MIT"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,8 @@ default = ["stream"]
 [lib]
 name = "ljmrs"
 path = "src/lib.rs"
+
+[[example]]
+name = "lua"
+path = "examples/lua.rs"
+required-features = ["lua"]

--- a/examples/config.rs
+++ b/examples/config.rs
@@ -1,11 +1,11 @@
 extern crate ljmrs;
 
-use ljmrs::LJMWrapper;
+use ljmrs::LJMLibrary;
 
 fn read() {
-    unsafe { LJMWrapper::init(None) }.unwrap();
+    unsafe { LJMLibrary::init(None) }.unwrap();
 
-    let open_call = LJMWrapper::open_jack(
+    let open_call = LJMLibrary::open_jack(
         ljmrs::DeviceType::ANY,
         ljmrs::ConnectionType::ANY,
         "-2".to_string(),
@@ -13,17 +13,17 @@ fn read() {
 
     println!("Opened LabJack, got handle: {}", open_call);
 
-    let read_value = LJMWrapper::get_config("LJM_STREAM_SCANS_RETURN".to_string())
+    let read_value = LJMLibrary::get_config("LJM_STREAM_SCANS_RETURN".to_string())
         .expect("Expected Value");
 
     println!("Got configuration value: {}", read_value);
 
-    LJMWrapper::set_config("LJM_STREAM_SCANS_RETURN".to_string(), 2)
+    LJMLibrary::set_config("LJM_STREAM_SCANS_RETURN".to_string(), 2)
         .expect("Expected Value");
 
     println!("Set config value to 2, reading...");
 
-    let read_value = LJMWrapper::get_config("LJM_STREAM_SCANS_RETURN".to_string())
+    let read_value = LJMLibrary::get_config("LJM_STREAM_SCANS_RETURN".to_string())
         .expect("Expected Value");
 
     println!("Got new configuration value: {}", read_value);

--- a/examples/config.rs
+++ b/examples/config.rs
@@ -3,32 +3,27 @@ extern crate ljmrs;
 use ljmrs::LJMWrapper;
 
 fn read() {
-    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+    unsafe { LJMWrapper::init(None) }.unwrap();
 
-    let open_call = ljm_wrapper
-        .open_jack(
-            ljmrs::DeviceType::ANY,
-            ljmrs::ConnectionType::ANY,
-            "-2".to_string(),
-        )
-        .expect("Could not open DEMO LabJack");
+    let open_call = LJMWrapper::open_jack(
+        ljmrs::DeviceType::ANY,
+        ljmrs::ConnectionType::ANY,
+        "-2".to_string(),
+    ).expect("Could not open DEMO LabJack");
 
     println!("Opened LabJack, got handle: {}", open_call);
 
-    let read_value = ljm_wrapper
-        .get_config("LJM_STREAM_SCANS_RETURN".to_string())
+    let read_value = LJMWrapper::get_config("LJM_STREAM_SCANS_RETURN".to_string())
         .expect("Expected Value");
 
     println!("Got configuration value: {}", read_value);
 
-    ljm_wrapper
-        .set_config("LJM_STREAM_SCANS_RETURN".to_string(), 2)
+    LJMWrapper::set_config("LJM_STREAM_SCANS_RETURN".to_string(), 2)
         .expect("Expected Value");
 
     println!("Set config value to 2, reading...");
 
-    let read_value = ljm_wrapper
-        .get_config("LJM_STREAM_SCANS_RETURN".to_string())
+    let read_value = LJMWrapper::get_config("LJM_STREAM_SCANS_RETURN".to_string())
         .expect("Expected Value");
 
     println!("Got new configuration value: {}", read_value);

--- a/examples/direct.rs
+++ b/examples/direct.rs
@@ -5,30 +5,21 @@ use std::time::Instant;
 use ljmrs::LJMWrapper;
 
 fn stream() {
-    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+    unsafe { LJMWrapper::init(None) }.unwrap();
 
-    let open_call = ljm_wrapper
-        .open_jack(
-            ljmrs::DeviceType::ANY,
-            ljmrs::ConnectionType::ANY,
-            "ANY".to_string(),
-        )
-        .expect("Could not open DEMO LabJack");
+    let open_call = LJMWrapper::open_jack(
+        ljmrs::DeviceType::ANY,
+        ljmrs::ConnectionType::ANY,
+        "-2".to_string(), // Use "ANY" for physical hardware
+    ).expect("Could not open DEMO LabJack");
 
     println!("Opened LabJack, got handle: {}", open_call);
 
     let now = Instant::now();
 
-    let mut i = 0;
-    while i < 50 {
-        ljm_wrapper
-            .read_name(open_call, "AIN0")
-            .expect("");
-        ljm_wrapper
-            .read_name(open_call, "AIN1")
-            .expect("");
-
-        i += 1;
+    for _ in 0..50 {
+        LJMWrapper::read_name(open_call, "AIN0").expect("");
+        LJMWrapper::read_name(open_call, "AIN1").expect("");
     }
 
     let elapsed = now.elapsed();

--- a/examples/direct.rs
+++ b/examples/direct.rs
@@ -2,12 +2,12 @@ extern crate ljmrs;
 
 use std::time::Instant;
 
-use ljmrs::LJMWrapper;
+use ljmrs::LJMLibrary;
 
 fn stream() {
-    unsafe { LJMWrapper::init(None) }.unwrap();
+    unsafe { LJMLibrary::init(None) }.unwrap();
 
-    let open_call = LJMWrapper::open_jack(
+    let open_call = LJMLibrary::open_jack(
         ljmrs::DeviceType::ANY,
         ljmrs::ConnectionType::ANY,
         "-2".to_string(), // Use "ANY" for physical hardware
@@ -18,8 +18,8 @@ fn stream() {
     let now = Instant::now();
 
     for _ in 0..50 {
-        LJMWrapper::read_name(open_call, "AIN0").expect("");
-        LJMWrapper::read_name(open_call, "AIN1").expect("");
+        LJMLibrary::read_name(open_call, "AIN0").expect("");
+        LJMLibrary::read_name(open_call, "AIN1").expect("");
     }
 
     let elapsed = now.elapsed();

--- a/examples/direct.rs
+++ b/examples/direct.rs
@@ -22,10 +22,10 @@ fn stream() {
     let mut i = 0;
     while i < 50 {
         ljm_wrapper
-            .read_name(open_call, "AIN0".to_string())
+            .read_name(open_call, "AIN0")
             .expect("");
         ljm_wrapper
-            .read_name(open_call, "AIN1".to_string())
+            .read_name(open_call, "AIN1")
             .expect("");
 
         i += 1;

--- a/examples/example.lua
+++ b/examples/example.lua
@@ -1,0 +1,29 @@
+-- This example was obtained from the official labjack documentation:
+-- https://github.com/labjack/labjack-ljm-python/blob/master/Examples/More/Lua/lua_execution_control.py
+
+local ramval = 0
+MB.W(46180, 0, ramval)
+local loop0 = 0
+local loop1 = 1
+local loop2 = 2
+
+-- Setup an interval to control loop execution speed. Update every second
+LJ.IntervalConfig(0,1000)
+while true do
+  if LJ.CheckInterval(0) then
+    ramval = MB.R(46180, 0)
+
+    if ramval == loop0 then
+      print("using loop0")
+    end
+
+    if ramval == loop1 then
+      print("using loop1")
+    end
+
+    if ramval == loop2 then
+      print("using loop2")
+    end
+
+  end
+end

--- a/examples/info.rs
+++ b/examples/info.rs
@@ -1,11 +1,11 @@
 extern crate ljmrs;
 
-use ljmrs::LJMWrapper;
+use ljmrs::LJMLibrary;
 
 fn info() {
-    unsafe { LJMWrapper::init(None) }.unwrap();
+    unsafe { LJMLibrary::init(None) }.unwrap();
 
-    let open_call = LJMWrapper::open_jack(
+    let open_call = LJMLibrary::open_jack(
         ljmrs::DeviceType::ANY,
         ljmrs::ConnectionType::ANY,
         "-2".to_string(),
@@ -14,13 +14,13 @@ fn info() {
     println!("Opened LabJack, got handle: {}", &open_call);
 
     let info =
-        LJMWrapper::get_handle_info(open_call).expect("Handle verification failed.");
+        LJMLibrary::get_handle_info(open_call).expect("Handle verification failed.");
 
     println!("--- LabJack Info ---\n{}\n--- LabJack Info ---", info);
 
     // The C String recovery is an unsafe process
     let ip = unsafe {
-        LJMWrapper::number_to_ip(info.ip_address).expect("Could not convert IP.")
+        LJMLibrary::number_to_ip(info.ip_address).expect("Could not convert IP.")
     };
     println!("IP: {ip}");
 }

--- a/examples/info.rs
+++ b/examples/info.rs
@@ -3,28 +3,24 @@ extern crate ljmrs;
 use ljmrs::LJMWrapper;
 
 fn info() {
-    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+    unsafe { LJMWrapper::init(None) }.unwrap();
 
-    let open_call = ljm_wrapper
-        .open_jack(
-            ljmrs::DeviceType::ANY,
-            ljmrs::ConnectionType::ANY,
-            "-2".to_string(),
-        )
-        .expect("Could not open DEMO LabJack");
+    let open_call = LJMWrapper::open_jack(
+        ljmrs::DeviceType::ANY,
+        ljmrs::ConnectionType::ANY,
+        "-2".to_string(),
+    ).expect("Could not open DEMO LabJack");
 
     println!("Opened LabJack, got handle: {}", &open_call);
 
     let info =
-        LJMWrapper::get_handle_info(&ljm_wrapper, open_call).expect("Handle verification failed.");
+        LJMWrapper::get_handle_info(open_call).expect("Handle verification failed.");
 
     println!("--- LabJack Info ---\n{}\n--- LabJack Info ---", info);
 
     // The C String recovery is an unsafe process
     let ip = unsafe {
-        ljm_wrapper
-            .number_to_ip(info.ip_address)
-            .expect("Could not convert IP.")
+        LJMWrapper::number_to_ip(info.ip_address).expect("Could not convert IP.")
     };
     println!("IP: {ip}");
 }

--- a/examples/library.rs
+++ b/examples/library.rs
@@ -4,15 +4,13 @@ use ljmrs::LJMWrapper;
 
 fn library() {
     let unique_library_location = "/usr/lib/ljm/libLabJackM.dylib".to_string();
-    let ljm_wrapper = unsafe { LJMWrapper::init(Some(unique_library_location)) }.unwrap();
+    unsafe { LJMWrapper::init(Some(unique_library_location)) }.unwrap();
 
-    let open_call = ljm_wrapper
-        .open_jack(
-            ljmrs::DeviceType::ANY,
-            ljmrs::ConnectionType::ANY,
-            "-2".to_string(),
-        )
-        .expect("Could not open DEMO LabJack");
+    let open_call = LJMWrapper::open_jack(
+        ljmrs::DeviceType::ANY,
+        ljmrs::ConnectionType::ANY,
+        "-2".to_string(),
+    ).expect("Could not open DEMO LabJack");
 
     println!("Opened LabJack, got handle: {}", &open_call);
 }

--- a/examples/library.rs
+++ b/examples/library.rs
@@ -1,12 +1,12 @@
 extern crate ljmrs;
 
-use ljmrs::LJMWrapper;
+use ljmrs::LJMLibrary;
 
 fn library() {
     let unique_library_location = "/usr/lib/ljm/libLabJackM.dylib".to_string();
-    unsafe { LJMWrapper::init(Some(unique_library_location)) }.unwrap();
+    unsafe { LJMLibrary::init(Some(unique_library_location)) }.unwrap();
 
-    let open_call = LJMWrapper::open_jack(
+    let open_call = LJMLibrary::open_jack(
         ljmrs::DeviceType::ANY,
         ljmrs::ConnectionType::ANY,
         "-2".to_string(),

--- a/examples/load.rs
+++ b/examples/load.rs
@@ -2,14 +2,14 @@ extern crate ljmrs;
 
 use std::time::Instant;
 
-use ljmrs::LJMWrapper;
+use ljmrs::LJMLibrary;
 
 fn load() {
     let now = Instant::now();
 
-    unsafe { LJMWrapper::init(None) }.unwrap();
+    unsafe { LJMLibrary::init(None) }.unwrap();
 
-    let open_call = LJMWrapper::open_jack(
+    let open_call = LJMLibrary::open_jack(
         ljmrs::DeviceType::ANY,
         ljmrs::ConnectionType::ANY,
         "-2".to_string(),
@@ -24,7 +24,7 @@ fn load() {
 
     let name: &str = "FIO0";
 
-    let (addr, typ) = LJMWrapper::name_to_address(name)
+    let (addr, typ) = LJMLibrary::name_to_address(name)
         .expect("Expected NTA");
     println!("{name} => Address: {}, Type: {}", addr, typ);
 

--- a/examples/load.rs
+++ b/examples/load.rs
@@ -7,15 +7,13 @@ use ljmrs::LJMWrapper;
 fn load() {
     let now = Instant::now();
 
-    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+    unsafe { LJMWrapper::init(None) }.unwrap();
 
-    let open_call = ljm_wrapper
-        .open_jack(
-            ljmrs::DeviceType::ANY,
-            ljmrs::ConnectionType::ANY,
-            "-2".to_string(),
-        )
-        .expect("Could not open DEMO LabJack");
+    let open_call = LJMWrapper::open_jack(
+        ljmrs::DeviceType::ANY,
+        ljmrs::ConnectionType::ANY,
+        "-2".to_string(),
+    ).expect("Could not open DEMO LabJack");
 
     println!("Opened LabJack, got handle: {}", open_call);
 
@@ -26,8 +24,7 @@ fn load() {
 
     let name: &str = "FIO0";
 
-    let (addr, typ) = ljm_wrapper
-        .name_to_address(name)
+    let (addr, typ) = LJMWrapper::name_to_address(name)
         .expect("Expected NTA");
     println!("{name} => Address: {}, Type: {}", addr, typ);
 

--- a/examples/lua.rs
+++ b/examples/lua.rs
@@ -1,6 +1,6 @@
 extern crate ljmrs;
 
-use ljmrs::{LJMWrapper, LuaModule};
+use ljmrs::{LJMLibrary, LuaModule};
 
 const SCRIPT: &str = r#"
 local ramval = 0
@@ -32,9 +32,9 @@ end
 "#;
 
 fn init() -> i32 {
-    unsafe { LJMWrapper::init(None) }.unwrap();
+    unsafe { LJMLibrary::init(None) }.unwrap();
 
-    LJMWrapper::open_jack(
+    LJMLibrary::open_jack(
         ljmrs::DeviceType::ANY,
         ljmrs::ConnectionType::ANY,
         "-2".to_string(),
@@ -49,7 +49,7 @@ async fn main() {
     let module = LuaModule::new(SCRIPT);
     println!("Setting LUA module of size: {}", module.size());
 
-    LJMWrapper::set_module(open_call, module).await.unwrap();
+    LJMLibrary::set_module(open_call, module).await.unwrap();
     println!("Module set!");
 }
 
@@ -59,6 +59,6 @@ fn main() {
     let module = LuaModule::new(SCRIPT);
     println!("Setting LUA module of size: {}", module.size());
 
-    LJMWrapper::set_module(open_call, module).unwrap();
+    LJMLibrary::set_module(open_call, module).unwrap();
     println!("Module set!");
 }

--- a/examples/lua.rs
+++ b/examples/lua.rs
@@ -31,37 +31,34 @@ while true do
 end
 "#;
 
-fn init() -> (i32, LJMWrapper) {
-    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+fn init() -> i32 {
+    unsafe { LJMWrapper::init(None) }.unwrap();
 
-    (ljm_wrapper
-         .open_jack(
-             ljmrs::DeviceType::ANY,
-             ljmrs::ConnectionType::ANY,
-             "-2".to_string(),
-         )
-         .expect("Could not open DEMO LabJack"), ljm_wrapper)
+    LJMWrapper::open_jack(
+        ljmrs::DeviceType::ANY,
+        ljmrs::ConnectionType::ANY,
+        "-2".to_string(),
+    ).expect("Could not open DEMO LabJack")
 }
 
 #[cfg(feature = "tokio")]
 #[tokio::main]
 async fn main() {
-    let (open_call, ljm_wrapper) = init();
+    let open_call = init();
 
     let module = LuaModule::new(SCRIPT);
     println!("Setting LUA module of size: {}", module.size());
 
-    ljm_wrapper.set_module(open_call, module).await.unwrap();
+    LJMWrapper::set_module(open_call, module).await.unwrap();
     println!("Module set!");
 }
 
 #[cfg(not(feature = "tokio"))]
 fn main() {
-    let (open_call, ljm_wrapper) = init();
-
+    let open_call = init();
     let module = LuaModule::new(SCRIPT);
     println!("Setting LUA module of size: {}", module.size());
 
-    ljm_wrapper.set_module(open_call, module).unwrap();
+    LJMWrapper::set_module(open_call, module).unwrap();
     println!("Module set!");
 }

--- a/examples/lua.rs
+++ b/examples/lua.rs
@@ -1,0 +1,67 @@
+extern crate ljmrs;
+
+use ljmrs::{LJMWrapper, LuaModule};
+
+const SCRIPT: &str = r#"
+local ramval = 0
+MB.W(46180, 0, ramval)
+local loop0 = 0
+local loop1 = 1
+local loop2 = 2
+
+-- Setup an interval to control loop execution speed. Update every second
+LJ.IntervalConfig(0,1000)
+while true do
+  if LJ.CheckInterval(0) then
+    ramval = MB.R(46180, 0)
+
+    if ramval == loop0 then
+      print("using loop0")
+    end
+
+    if ramval == loop1 then
+      print("using loop1")
+    end
+
+    if ramval == loop2 then
+      print("using loop2")
+    end
+
+  end
+end
+"#;
+
+fn init() -> (i32, LJMWrapper) {
+    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+
+    (ljm_wrapper
+         .open_jack(
+             ljmrs::DeviceType::ANY,
+             ljmrs::ConnectionType::ANY,
+             "-2".to_string(),
+         )
+         .expect("Could not open DEMO LabJack"), ljm_wrapper)
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::main]
+async fn main() {
+    let (open_call, ljm_wrapper) = init();
+
+    let module = LuaModule::new(SCRIPT);
+    println!("Setting LUA module of size: {}", module.size());
+
+    ljm_wrapper.set_module(open_call, module).await.unwrap();
+    println!("Module set!");
+}
+
+#[cfg(not(feature = "tokio"))]
+fn main() {
+    let (open_call, ljm_wrapper) = init();
+
+    let module = LuaModule::new(SCRIPT);
+    println!("Setting LUA module of size: {}", module.size());
+
+    ljm_wrapper.set_module(open_call, module).unwrap();
+    println!("Module set!");
+}

--- a/examples/lua.rs
+++ b/examples/lua.rs
@@ -2,34 +2,7 @@ extern crate ljmrs;
 
 use ljmrs::{LJMLibrary, LuaModule};
 
-const SCRIPT: &str = r#"
-local ramval = 0
-MB.W(46180, 0, ramval)
-local loop0 = 0
-local loop1 = 1
-local loop2 = 2
-
--- Setup an interval to control loop execution speed. Update every second
-LJ.IntervalConfig(0,1000)
-while true do
-  if LJ.CheckInterval(0) then
-    ramval = MB.R(46180, 0)
-
-    if ramval == loop0 then
-      print("using loop0")
-    end
-
-    if ramval == loop1 then
-      print("using loop1")
-    end
-
-    if ramval == loop2 then
-      print("using loop2")
-    end
-
-  end
-end
-"#;
+const SCRIPT: &str = include_str!("example.lua");
 
 fn init() -> i32 {
     unsafe { LJMLibrary::init(None) }.unwrap();

--- a/examples/read.rs
+++ b/examples/read.rs
@@ -1,7 +1,8 @@
 extern crate ljmrs;
 
-use ljmrs::LJMWrapper;
 use std::time::Instant;
+
+use ljmrs::LJMWrapper;
 
 fn read() {
     let now = Instant::now();
@@ -24,7 +25,7 @@ fn read() {
     let now = Instant::now();
 
     let read_value = ljm_wrapper
-        .read_name(open_call, "TEST_INT32".to_string())
+        .read_name(open_call, "TEST_INT32")
         .expect("Expected Value");
     println!("Got: {}", read_value);
 
@@ -32,13 +33,13 @@ fn read() {
     println!("Elapsed: {:.2?}", elapsed);
 
     ljm_wrapper
-        .write_name(open_call, "TEST_INT32".to_string(), 15)
+        .write_name(open_call, "TEST_INT32", 15)
         .expect("Expected Value");
 
     let now = Instant::now();
 
     let read_value = ljm_wrapper
-        .read_name(open_call, "TEST_INT32".to_string())
+        .read_name(open_call, "TEST_INT32")
         .expect("Expected Value");
     println!("Got: {}", read_value);
 

--- a/examples/read.rs
+++ b/examples/read.rs
@@ -6,15 +6,13 @@ use ljmrs::LJMWrapper;
 
 fn read() {
     let now = Instant::now();
+    unsafe { LJMWrapper::init(None) }.unwrap();
 
-    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
-
-    let open_call = ljm_wrapper
-        .open_jack(
-            ljmrs::DeviceType::ANY,
-            ljmrs::ConnectionType::ANY,
-            "-2".to_string(),
-        )
+    let open_call = LJMWrapper::open_jack(
+        ljmrs::DeviceType::ANY,
+        ljmrs::ConnectionType::ANY,
+        "-2".to_string(),
+    )
         .expect("Could not open DEMO LabJack");
 
     println!("Opened LabJack, got handle: {}", open_call);
@@ -24,22 +22,20 @@ fn read() {
 
     let now = Instant::now();
 
-    let read_value = ljm_wrapper
-        .read_name(open_call, "TEST_INT32")
+    let read_value = LJMWrapper::read_name(open_call, "TEST_INT32")
         .expect("Expected Value");
+
     println!("Got: {}", read_value);
 
     let elapsed = now.elapsed();
     println!("Elapsed: {:.2?}", elapsed);
 
-    ljm_wrapper
-        .write_name(open_call, "TEST_INT32", 15)
+    LJMWrapper::write_name(open_call, "TEST_INT32", 15)
         .expect("Expected Value");
 
     let now = Instant::now();
 
-    let read_value = ljm_wrapper
-        .read_name(open_call, "TEST_INT32")
+    let read_value = LJMWrapper::read_name(open_call, "TEST_INT32")
         .expect("Expected Value");
     println!("Got: {}", read_value);
 

--- a/examples/read.rs
+++ b/examples/read.rs
@@ -2,13 +2,13 @@ extern crate ljmrs;
 
 use std::time::Instant;
 
-use ljmrs::LJMWrapper;
+use ljmrs::LJMLibrary;
 
 fn read() {
     let now = Instant::now();
-    unsafe { LJMWrapper::init(None) }.unwrap();
+    unsafe { LJMLibrary::init(None) }.unwrap();
 
-    let open_call = LJMWrapper::open_jack(
+    let open_call = LJMLibrary::open_jack(
         ljmrs::DeviceType::ANY,
         ljmrs::ConnectionType::ANY,
         "-2".to_string(),
@@ -22,7 +22,7 @@ fn read() {
 
     let now = Instant::now();
 
-    let read_value = LJMWrapper::read_name(open_call, "TEST_INT32")
+    let read_value = LJMLibrary::read_name(open_call, "TEST_INT32")
         .expect("Expected Value");
 
     println!("Got: {}", read_value);
@@ -30,12 +30,12 @@ fn read() {
     let elapsed = now.elapsed();
     println!("Elapsed: {:.2?}", elapsed);
 
-    LJMWrapper::write_name(open_call, "TEST_INT32", 15)
+    LJMLibrary::write_name(open_call, "TEST_INT32", 15)
         .expect("Expected Value");
 
     let now = Instant::now();
 
-    let read_value = LJMWrapper::read_name(open_call, "TEST_INT32")
+    let read_value = LJMLibrary::read_name(open_call, "TEST_INT32")
         .expect("Expected Value");
     println!("Got: {}", read_value);
 

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -2,12 +2,12 @@ extern crate ljmrs;
 
 use std::time::Instant;
 
-use ljmrs::LJMWrapper;
+use ljmrs::LJMLibrary;
 
 fn stream() {
-    unsafe { LJMWrapper::init(None) }.unwrap();
+    unsafe { LJMLibrary::init(None) }.unwrap();
 
-    let open_call = LJMWrapper::open_jack(
+    let open_call = LJMLibrary::open_jack(
         ljmrs::DeviceType::ANY,
         ljmrs::ConnectionType::ANY,
         "-2".to_string(), // Use "ANY" for physical hardware
@@ -20,16 +20,16 @@ fn stream() {
     // Do note that this examples will fail on
     // DEMO mode labjacks, as currently stream mode
     // is not supported for them.
-    LJMWrapper::stream_start(open_call, 2, 50_000.0, streams)
+    LJMLibrary::stream_start(open_call, 2, 50_000.0, streams)
         .expect("Failed to start stream");
 
-    assert!(LJMWrapper::is_stream_active());
+    assert!(LJMLibrary::is_stream_active());
 
     let now = Instant::now();
 
     let mut i = 0;
     while i < 50 {
-        let read_value = LJMWrapper::stream_read(open_call)
+        let read_value = LJMLibrary::stream_read(open_call)
             .expect("Could not read values");
 
         println!("Got {}: {:?}", read_value.len(), read_value);
@@ -39,9 +39,9 @@ fn stream() {
     let elapsed = now.elapsed();
     println!("Elapsed: {:.2?}", elapsed);
 
-    LJMWrapper::stream_stop(open_call).expect("Expected Value");
+    LJMLibrary::stream_stop(open_call).expect("Expected Value");
 
-    assert!(!LJMWrapper::is_stream_active());
+    assert!(!LJMLibrary::is_stream_active());
 }
 
 fn main() {

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -37,8 +37,6 @@ fn stream() {
             .expect("Could not read values");
 
         println!("Got {}: {:?}", read_value.len(), read_value);
-
-        // thread::sleep(Duration::from_millis(1));
         i += 1;
     }
 

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -5,15 +5,13 @@ use std::time::Instant;
 use ljmrs::LJMWrapper;
 
 fn stream() {
-    let mut ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+    unsafe { LJMWrapper::init(None) }.unwrap();
 
-    let open_call = ljm_wrapper
-        .open_jack(
-            ljmrs::DeviceType::ANY,
-            ljmrs::ConnectionType::ANY,
-            "ANY".to_string(),
-        )
-        .expect("Could not open DEMO LabJack");
+    let open_call = LJMWrapper::open_jack(
+        ljmrs::DeviceType::ANY,
+        ljmrs::ConnectionType::ANY,
+        "-2".to_string(), // Use "ANY" for physical hardware
+    ).expect("Could not open DEMO LabJack");
 
     println!("Opened LabJack, got handle: {}", open_call);
 
@@ -22,18 +20,16 @@ fn stream() {
     // Do note that this examples will fail on
     // DEMO mode labjacks, as currently stream mode
     // is not supported for them.
-    ljm_wrapper
-        .stream_start(open_call, 2, 50_000.0, streams)
+    LJMWrapper::stream_start(open_call, 2, 50_000.0, streams)
         .expect("Failed to start stream");
 
-    assert!(ljm_wrapper.is_stream_active());
+    assert!(LJMWrapper::is_stream_active());
 
     let now = Instant::now();
 
     let mut i = 0;
     while i < 50 {
-        let read_value = ljm_wrapper
-            .stream_read(open_call)
+        let read_value = LJMWrapper::stream_read(open_call)
             .expect("Could not read values");
 
         println!("Got {}: {:?}", read_value.len(), read_value);
@@ -43,9 +39,9 @@ fn stream() {
     let elapsed = now.elapsed();
     println!("Elapsed: {:.2?}", elapsed);
 
-    ljm_wrapper.stream_stop(open_call).expect("Expected Value");
+    LJMWrapper::stream_stop(open_call).expect("Expected Value");
 
-    assert!(!ljm_wrapper.is_stream_active());
+    assert!(!LJMWrapper::is_stream_active());
 }
 
 fn main() {

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -25,7 +25,7 @@ fn read() {
     let now = Instant::now();
 
     let read_value = ljm_wrapper
-        .read_name(open_call, "TEST_INT32".to_string())
+        .read_name(open_call, "TEST_INT32")
         .expect("Expected Value");
     println!("Got: {}", read_value);
 
@@ -33,13 +33,13 @@ fn read() {
     println!("Elapsed: {:.2?}", elapsed);
 
     ljm_wrapper
-        .write_name(open_call, "TEST_INT32".to_string(), 15)
+        .write_name(open_call, "TEST_INT32", 15)
         .expect("Expected Value");
 
     let now = Instant::now();
 
     let read_value = ljm_wrapper
-        .read_name(open_call, "TEST_INT32".to_string())
+        .read_name(open_call, "TEST_INT32")
         .expect("Expected Value");
     println!("Got: {}", read_value);
 

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -7,14 +7,13 @@ use ljmrs::LJMWrapper;
 fn read() {
     let now = Instant::now();
 
-    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+    unsafe { LJMWrapper::init(None).expect("Should have found library") };
 
-    let open_call = ljm_wrapper
-        .open_jack(
-            ljmrs::DeviceType::ANY,
-            ljmrs::ConnectionType::ANY,
-            "-2".to_string(),
-        )
+    let open_call = LJMWrapper::open_jack(
+        ljmrs::DeviceType::ANY,
+        ljmrs::ConnectionType::ANY,
+        "-2".to_string(),
+    )
         .expect("Could not open DEMO LabJack");
 
     println!("Opened LabJack, got handle: {}", open_call);
@@ -24,22 +23,19 @@ fn read() {
 
     let now = Instant::now();
 
-    let read_value = ljm_wrapper
-        .read_name(open_call, "TEST_INT32")
+    let read_value = LJMWrapper::read_name(open_call, "TEST_INT32")
         .expect("Expected Value");
     println!("Got: {}", read_value);
 
     let elapsed = now.elapsed();
     println!("Elapsed: {:.2?}", elapsed);
 
-    ljm_wrapper
-        .write_name(open_call, "TEST_INT32", 15)
+    LJMWrapper::write_name(open_call, "TEST_INT32", 15)
         .expect("Expected Value");
 
     let now = Instant::now();
 
-    let read_value = ljm_wrapper
-        .read_name(open_call, "TEST_INT32")
+    let read_value = LJMWrapper::read_name(open_call, "TEST_INT32")
         .expect("Expected Value");
     println!("Got: {}", read_value);
 

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -2,14 +2,14 @@ extern crate ljmrs;
 
 use std::time::Instant;
 
-use ljmrs::LJMWrapper;
+use ljmrs::LJMLibrary;
 
 fn read() {
     let now = Instant::now();
 
-    unsafe { LJMWrapper::init(None).expect("Should have found library") };
+    unsafe { LJMLibrary::init(None).expect("Should have found library") };
 
-    let open_call = LJMWrapper::open_jack(
+    let open_call = LJMLibrary::open_jack(
         ljmrs::DeviceType::ANY,
         ljmrs::ConnectionType::ANY,
         "-2".to_string(),
@@ -23,19 +23,19 @@ fn read() {
 
     let now = Instant::now();
 
-    let read_value = LJMWrapper::read_name(open_call, "TEST_INT32")
+    let read_value = LJMLibrary::read_name(open_call, "TEST_INT32")
         .expect("Expected Value");
     println!("Got: {}", read_value);
 
     let elapsed = now.elapsed();
     println!("Elapsed: {:.2?}", elapsed);
 
-    LJMWrapper::write_name(open_call, "TEST_INT32", 15)
+    LJMLibrary::write_name(open_call, "TEST_INT32", 15)
         .expect("Expected Value");
 
     let now = Instant::now();
 
-    let read_value = LJMWrapper::read_name(open_call, "TEST_INT32")
+    let read_value = LJMLibrary::read_name(open_call, "TEST_INT32")
         .expect("Expected Value");
     println!("Got: {}", read_value);
 

--- a/readme.md
+++ b/readme.md
@@ -1,22 +1,26 @@
 ### `ljmrs`
 
-A rust library which allows you to connect with the LabJack T7 and T8 series through the C/C++ Bindings. This is a rust abstraction layer for stronger types and safety.
+A rust library which allows you to connect with the LabJack T7 and T8 series through the C/C++ Bindings. This is a rust
+abstraction layer for stronger types and safety.
 
 You can install the [crate](https://crates.io/crates/ljmrs) with:
 
-```
+```rust,ignore
 cargo add ljmrs
 ```
 
 Types are provided for LabJack error codes, as a return value for each function.
 
-Documentation is supported around the [wrapper](./ljm/wrapper/struct.LJMWrapper.html). To find equivalent functions of LJM functions, use [search and enter the LJM function name](./index.html?search=LJM_eReadName).
+Documentation is supported around the [wrapper](./ljm/wrapper/struct.LJMWrapper.html). To find equivalent functions of
+LJM functions, use [search and enter the LJM function name](./index.html?search=LJM_eReadName).
 
 #### Support
 
 This **does not support** every function yet, you are welcome to create a PR to add any functions you want.
 
-The official documentation from LabJack is found [here](https://labjack.com/pages/support/software?doc=/software-driver/ljm-users-guide/ljm-users-guide/). `ljm-rs` simply provides abstraction to the C/C++ library, through the `libloading` crate.
+The official documentation from LabJack is
+found [here](https://labjack.com/pages/support/software?doc=/software-driver/ljm-users-guide/ljm-users-guide/). `ljm-rs`
+simply provides abstraction to the C/C++ library, through the `libloading` crate.
 
 #### Examples
 
@@ -36,8 +40,10 @@ Got IP, 109.61.99.68
 
 #### Addendum
 
-Note, running on MacOS with an ARM CPU requires newer versions of LabJack software, found [here](https://labjack.com/pages/support?doc=/software-driver/installer-downloads/ljm-software-installers-t4-t7-digit/#header-three-ak4ld).
-Alternatively, you can use [Rosetta 2](https://support.apple.com/en-us/HT211861) with older software, and the following command:
+Note, running on MacOS with an ARM CPU requires newer versions of LabJack software,
+found [here](https://labjack.com/pages/support?doc=/software-driver/installer-downloads/ljm-software-installers-t4-t7-digit/#header-three-ak4ld).
+Alternatively, you can use [Rosetta 2](https://support.apple.com/en-us/HT211861) with older software, and the following
+command:
 
 ```bash
 cargo build && arch -x86_64 ./target/x86_64-apple-darwin/debug/ljm-rs

--- a/src/ljm/error.rs
+++ b/src/ljm/error.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use crate::LJMWrapper;
+use crate::LJMLibrary;
 
 /// Taken from: [LJM ErrorCodes](https://labjack.com/pages/support?doc=%2Fsoftware-driver%2Fljm-users-guide%2Ferror-codes%2F)
 ///
@@ -66,7 +66,7 @@ impl Debug for LJMErrorCode {
 }
 
 pub enum LJMError {
-    WrapperInvalid(LJMWrapper),
+    WrapperInvalid(LJMLibrary),
     StartupError(libloading::Error),
     ErrorCode(LJMErrorCode, String),
     LibraryError(String),

--- a/src/ljm/error.rs
+++ b/src/ljm/error.rs
@@ -70,6 +70,8 @@ pub enum LJMError {
     LibloadingError(libloading::Error),
     Uninitialized,
     StreamNotStarted,
+    ScriptNotSet,
+    ScriptStillRunning,
 }
 
 impl From<libloading::Error> for LJMError {
@@ -90,6 +92,8 @@ impl Debug for LJMError {
                 LJMError::LibraryError(error) => format!("LibraryError::{:?}", error),
                 LJMError::Uninitialized => "UninitializedError".to_string(),
                 LJMError::StreamNotStarted => "StreamNotStartedError".to_string(),
+                LJMError::ScriptStillRunning => "ScriptStillRunningError".to_string(),
+                LJMError::ScriptNotSet => "ScriptNotSetError".to_string()
             }
         )
     }

--- a/src/ljm/error.rs
+++ b/src/ljm/error.rs
@@ -1,5 +1,7 @@
 use std::fmt::Debug;
 
+use crate::LJMWrapper;
+
 /// Taken from: [LJM ErrorCodes](https://labjack.com/pages/support?doc=%2Fsoftware-driver%2Fljm-users-guide%2Ferror-codes%2F)
 ///
 /// > Note:
@@ -64,6 +66,7 @@ impl Debug for LJMErrorCode {
 }
 
 pub enum LJMError {
+    WrapperInvalid(LJMWrapper),
     StartupError(libloading::Error),
     ErrorCode(LJMErrorCode, String),
     LibraryError(String),
@@ -93,7 +96,8 @@ impl Debug for LJMError {
                 LJMError::Uninitialized => "UninitializedError".to_string(),
                 LJMError::StreamNotStarted => "StreamNotStartedError".to_string(),
                 LJMError::ScriptStillRunning => "ScriptStillRunningError".to_string(),
-                LJMError::ScriptNotSet => "ScriptNotSetError".to_string()
+                LJMError::ScriptNotSet => "ScriptNotSetError".to_string(),
+                LJMError::WrapperInvalid(_) => "WrapperInvalidError".to_string()
             }
         )
     }

--- a/src/ljm/lua.rs
+++ b/src/ljm/lua.rs
@@ -1,0 +1,20 @@
+#[derive(Clone)]
+pub struct LuaModule {
+    script: String,
+}
+
+impl LuaModule {
+    pub fn new(module: &str) -> Self {
+        LuaModule {
+            script: module.to_string()
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        self.script.len()
+    }
+
+    pub fn script(&self) -> String {
+        self.script.clone()
+    }
+}

--- a/src/ljm/lua.rs
+++ b/src/ljm/lua.rs
@@ -10,7 +10,7 @@ impl Into<LuaModule> for String {
 }
 
 impl LuaModule {
-    pub fn new<T: Into<String>>(module: T) -> Self {
+    pub fn new<T: ToString>(module: T) -> Self {
         LuaModule {
             script: module.to_string()
         }

--- a/src/ljm/lua.rs
+++ b/src/ljm/lua.rs
@@ -3,8 +3,14 @@ pub struct LuaModule {
     script: String,
 }
 
+impl Into<LuaModule> for String {
+    fn into(self) -> LuaModule {
+        LuaModule::new(self)
+    }
+}
+
 impl LuaModule {
-    pub fn new(module: &str) -> Self {
+    pub fn new<T: Into<String>>(module: T) -> Self {
         LuaModule {
             script: module.to_string()
         }

--- a/src/ljm/mod.rs
+++ b/src/ljm/mod.rs
@@ -1,7 +1,10 @@
-pub mod error;
-pub mod handle;
-pub mod wrapper;
-
 pub use error::*;
 pub use handle::*;
+pub use lua::*;
 pub use wrapper::*;
+
+pub mod error;
+pub mod handle;
+pub mod lua;
+pub mod wrapper;
+

--- a/src/ljm/wrapper.rs
+++ b/src/ljm/wrapper.rs
@@ -552,12 +552,12 @@ impl LJMWrapper {
     }
 
     #[cfg(feature = "lua")]
-    pub fn lua_running(&self, handle: i32) -> Result<bool, LJMError> {
+    pub fn module_running(&self, handle: i32) -> Result<bool, LJMError> {
         Ok(self.read_name(handle, "LUA_RUN")? == 1_f64)
     }
 
     #[cfg(all(feature = "lua", feature = "tokio"))]
-    pub async fn stop_lua(&self, handle: i32) -> Result<(), LJMError> {
+    pub async fn stop_module(&self, handle: i32) -> Result<(), LJMError> {
         let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(50));
 
         while self.lua_running(handle)? {
@@ -569,7 +569,7 @@ impl LJMWrapper {
     }
 
     #[cfg(all(feature = "lua", not(feature = "tokio")))]
-    pub fn stop_lua(&self, handle: i32) -> Result<(), LJMError> {
+    pub fn stop_module(&self, handle: i32) -> Result<(), LJMError> {
         while self.lua_running(handle)? {
             self.write_name(handle, "LUA_RUN", 0)?;
             std::thread::sleep(std::time::Duration::from_millis(50))

--- a/src/ljm/wrapper.rs
+++ b/src/ljm/wrapper.rs
@@ -539,6 +539,7 @@ impl LJMWrapper {
         Ok(())
     }
 
+    #[cfg(feature = "lua")]
     fn replace_module(&self, handle: i32, module: LuaModule) -> Result<(), LJMError> {
         // If there is a script still running, we shouldn't replace anything.
         if self.lua_running(handle)? {

--- a/src/ljm/wrapper.rs
+++ b/src/ljm/wrapper.rs
@@ -211,10 +211,10 @@ impl LJMWrapper {
     /// Takes a handle to the labjack, the name to be written and the value to be written.
     /// Does not return a value.
     #[doc(alias = "LJM_eWriteName")]
-    pub fn write_name(
+    pub fn write_name<T: Into<Vec<u8>>>(
         &self,
         handle: i32,
-        name_to_write: &str,
+        name_to_write: T,
         value_to_write: u32,
     ) -> Result<(), LJMError> {
         let d_write_to_addr: Symbol<extern "C" fn(i32, *const c_char, c_double) -> i32> =
@@ -229,12 +229,12 @@ impl LJMWrapper {
     }
 
     #[doc(alias = "LJM_eWriteNameByteArray")]
-    pub fn write_name_byte_array<T: Into<Vec<u8>>>(
+    pub fn write_name_byte_array<T: Into<Vec<u8>>, B: Into<Vec<u8>>>(
         &self,
         handle: i32,
-        name_to_write: &str,
+        name_to_write: T,
         size: i32,
-        bytes: T,
+        bytes: B,
     ) -> Result<(), LJMError> {
         let d_write_name_byte_array: Symbol<extern "C" fn(i32, *const c_char, i32, *const c_char, *mut i32) -> i32> =
             unsafe { self.get_c_function(b"LJM_eWriteNameByteArray")? };
@@ -259,7 +259,7 @@ impl LJMWrapper {
     /// Reads from a labjack given the handle and name to read.
     /// Returns an f64 value that is read from the labjack.
     #[doc(alias = "LJM_eReadName")]
-    pub fn read_name(&self, handle: i32, name_to_read: &str) -> Result<f64, LJMError> {
+    pub fn read_name<T: Into<Vec<u8>>>(&self, handle: i32, name_to_read: T) -> Result<f64, LJMError> {
         let d_read_from_aadr: Symbol<extern "C" fn(i32, *const c_char, *mut c_double) -> i32> =
             unsafe { self.get_c_function(b"LJM_eReadName")? };
 

--- a/tests/mem.rs
+++ b/tests/mem.rs
@@ -1,5 +1,5 @@
 use ljmrs;
-use ljmrs::{LJMError, LJMErrorCode, LJMWrapper};
+use ljmrs::{LJMError, LJMErrorCode, LJMLibrary};
 
 fn assert_error(error: LJMError, error_code: i32) {
     assert!(
@@ -14,7 +14,7 @@ fn assert_error(error: LJMError, error_code: i32) {
 
 #[test]
 fn bad_open() {
-    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+    let ljm_wrapper = unsafe { LJMLibrary::init(None) }.unwrap();
 
     // Forge a fake handle
     let handle: i32 = -1;
@@ -29,7 +29,7 @@ fn bad_open() {
 
 #[test]
 fn fake_write() {
-    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+    let ljm_wrapper = unsafe { LJMLibrary::init(None) }.unwrap();
 
     // Forge a fake handle
     let handle: i32 = -1;
@@ -48,7 +48,7 @@ fn fake_write() {
 
 #[test]
 fn use_after_write() {
-    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+    let ljm_wrapper = unsafe { LJMLibrary::init(None) }.unwrap();
 
     // Forge a fake handle
     let handle: i32 = -1;
@@ -68,7 +68,7 @@ fn use_after_write() {
 // when called by rust's automatic `drop` calls, as it may lead to a double free.
 #[test]
 fn uaw2() {
-    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+    let ljm_wrapper = unsafe { LJMLibrary::init(None) }.unwrap();
 
     // Forge a fake handle
     let handle: i32 = -1;

--- a/tests/mem.rs
+++ b/tests/mem.rs
@@ -14,11 +14,11 @@ fn assert_error(error: LJMError, error_code: i32) {
 
 #[test]
 fn bad_open() {
-    let ljm_wrapper = unsafe { LJMLibrary::init(None) }.unwrap();
+    let _ = unsafe { LJMLibrary::init(None) };
 
     // Forge a fake handle
     let handle: i32 = -1;
-    let result = ljm_wrapper.read_name(handle, "AIN0".to_string());
+    let result = LJMLibrary::read_name(handle, "AIN0".to_string());
 
     assert!(result.is_err());
 
@@ -29,7 +29,7 @@ fn bad_open() {
 
 #[test]
 fn fake_write() {
-    let ljm_wrapper = unsafe { LJMLibrary::init(None) }.unwrap();
+    let _ = unsafe { LJMLibrary::init(None) };
 
     // Forge a fake handle
     let handle: i32 = -1;
@@ -37,7 +37,7 @@ fn fake_write() {
     // Forge a pin num. AIN2 with a _RANGE property
     let modbus_range = format!("{}_RANGE", "AIN2");
 
-    let result = ljm_wrapper.write_name(handle, modbus_range, 0);
+    let result = LJMLibrary::write_name(handle, modbus_range, 0);
 
     assert!(result.is_err());
 
@@ -48,7 +48,7 @@ fn fake_write() {
 
 #[test]
 fn use_after_write() {
-    let ljm_wrapper = unsafe { LJMLibrary::init(None) }.unwrap();
+    let _ = unsafe { LJMLibrary::init(None) };
 
     // Forge a fake handle
     let handle: i32 = -1;
@@ -56,7 +56,7 @@ fn use_after_write() {
     // Forge a pin num. AIN2 with a _RANGE property
     let modbus_range = format!("{}_RANGE", "AIN2");
 
-    let result = ljm_wrapper.write_name(handle, modbus_range, 0);
+    let result = LJMLibrary::write_name(handle, modbus_range, 0);
 
     assert!(result.is_err());
     let error: LJMError = result.err().unwrap();
@@ -68,14 +68,13 @@ fn use_after_write() {
 // when called by rust's automatic `drop` calls, as it may lead to a double free.
 #[test]
 fn uaw2() {
-    let ljm_wrapper = unsafe { LJMLibrary::init(None) }.unwrap();
+    let _ = unsafe { LJMLibrary::init(None) };
 
     // Forge a fake handle
     let handle: i32 = -1;
 
     // Block scope to auto-drop this block.
     {
-        let wrapper = &ljm_wrapper;
         let handle_ref = &handle;
 
         // Forge a pin num. AIN2 with a _RANGE property
@@ -83,7 +82,7 @@ fn uaw2() {
         let modbus_range = format!("{}_RANGE", pin);
         let range = 0;
 
-        if let Err(error) = wrapper.write_name(handle_ref.clone(), modbus_range.clone(), range) {
+        if let Err(error) = LJMLibrary::write_name(handle_ref.clone(), modbus_range.clone(), range) {
             println!(
                 "Unable to write modbus range {} for {}, on {}. Reason: {:?}",
                 range, modbus_range, handle_ref, error

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use ljmrs;
-use ljmrs::{LJMError, LJMErrorCode, LJMWrapper};
+use ljmrs::{LJMError, LJMErrorCode, LJMLibrary};
 
 fn assert_error(error: LJMError, error_code: i32) {
     assert!(
@@ -16,7 +16,7 @@ fn assert_error(error: LJMError, error_code: i32) {
 
 #[test]
 fn open() {
-    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+    let ljm_wrapper = unsafe { LJMLibrary::init(None) }.unwrap();
 
     let open_call = ljm_wrapper
         .open_jack(
@@ -30,7 +30,7 @@ fn open() {
 
 #[test]
 fn get_name() {
-    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+    let ljm_wrapper = unsafe { LJMLibrary::init(None) }.unwrap();
 
     let mut elapsed_times: Vec<f32> = vec![];
     let addresses = vec!["AIN0", "AIN1", "AIN2", "AIN3", "FIO0", "FIO1"];
@@ -50,7 +50,7 @@ fn get_name() {
 
 #[test]
 fn standard_open_read() {
-    let ljm_wrapper = unsafe { LJMWrapper::init(None) }.unwrap();
+    let ljm_wrapper = unsafe { LJMLibrary::init(None) }.unwrap();
 
     let open_call = ljm_wrapper
         .open_jack(

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -1,43 +1,31 @@
 use std::time::Instant;
 
 use ljmrs;
-use ljmrs::{LJMError, LJMErrorCode, LJMLibrary};
-
-fn assert_error(error: LJMError, error_code: i32) {
-    assert!(
-        matches!(
-            error,
-            LJMError::ErrorCode(
-               i, _j
-            ) if i == LJMErrorCode::from(error_code)
-        )
-    );
-}
+use ljmrs::LJMLibrary;
 
 #[test]
 fn open() {
-    let ljm_wrapper = unsafe { LJMLibrary::init(None) }.unwrap();
+    let _ = unsafe { LJMLibrary::init(None) };
 
-    let open_call = ljm_wrapper
-        .open_jack(
-            ljmrs::DeviceType::ANY,
-            ljmrs::ConnectionType::ANY,
-            "-2".to_string(),
-        );
+    let open_call = LJMLibrary::open_jack(
+        ljmrs::DeviceType::ANY,
+        ljmrs::ConnectionType::ANY,
+        "-2".to_string(),
+    );
 
     assert!(open_call.is_ok());
 }
 
 #[test]
 fn get_name() {
-    let ljm_wrapper = unsafe { LJMLibrary::init(None) }.unwrap();
+    let _ = unsafe { LJMLibrary::init(None) };
 
     let mut elapsed_times: Vec<f32> = vec![];
     let addresses = vec!["AIN0", "AIN1", "AIN2", "AIN3", "FIO0", "FIO1"];
 
     for _ in 0..addresses.len() {
         let now = Instant::now();
-        let result = ljm_wrapper.name_to_address("AIN0".to_string());
+        let result = LJMLibrary::name_to_address("AIN0".to_string());
         assert!(result.is_ok());
 
         let elapsed = now.elapsed().as_millis();
@@ -50,20 +38,17 @@ fn get_name() {
 
 #[test]
 fn standard_open_read() {
-    let ljm_wrapper = unsafe { LJMLibrary::init(None) }.unwrap();
+    let _ = unsafe { LJMLibrary::init(None) };
 
-    let open_call = ljm_wrapper
-        .open_jack(
-            ljmrs::DeviceType::ANY,
-            ljmrs::ConnectionType::ANY,
-            "-2".to_string(),
-        )
-        .expect("Could not open DEMO LabJack");
+    let open_call = LJMLibrary::open_jack(
+        ljmrs::DeviceType::ANY,
+        ljmrs::ConnectionType::ANY,
+        "-2".to_string(),
+    ).expect("Could not open DEMO LabJack");
 
     assert_ne!(open_call, -1);
 
-    let read_value = ljm_wrapper
-        .read_name(open_call, "TEST_INT32".to_string())
+    let read_value = LJMLibrary::read_name(open_call, "TEST_INT32".to_string())
         .expect("Expected Value");
 
     assert_eq!(read_value, 0f64);


### PR DESCRIPTION
Bumps version to `0.2.0`, as introduces breaking changes.

### Changes
- Adds `lua` and `tokio` features.
- Makes `name_to_write` any `Into<Vec<u8>>`, allowing for `&str` and `String`.
- Adds `set_module(i32, LuaModule)` function
- Adds `module_running` and `stop_module` functions
- Adds `examples/lua.rs` example
- Adds `LuaModule` structure, creatable from any `Into<String>` item
- Renames `LJMWrapper` to `LJMLibrary`
- Removes reliance on `self` for function calls (`wrapper.read_name(...) -> LJMLibrary::read_name(...)`) so instances don't have to be carried around.
- Updates tests to match