### PR TITLE
fix: Allow any `Into<c_double>`, where applicable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ljmrs"
-version = "0.2.0"
+version = "0.2.1"
 description = "LabJack LJM Bindings for Rust"
 license = "MIT"
 edition = "2021"

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -31,6 +31,9 @@ fn read() {
     LJMLibrary::write_name(open_call, "TEST_INT32", 15)
         .expect("Expected Value");
 
+    LJMLibrary::write_name(open_call, "DAC0", 2.5)
+        .expect("Expected Value");
+
     let now = Instant::now();
 
     let read_value = LJMLibrary::read_name(open_call, "TEST_INT32")

--- a/src/ljm/core.rs
+++ b/src/ljm/core.rs
@@ -10,7 +10,7 @@ use std::{fmt::Display, sync::RwLock};
 #[cfg(feature = "dynlink")]
 use libloading::{Library, Symbol};
 
-use crate::{lib, ljm::handle::{ConnectionType, DeviceHandleInfo, DeviceType}, LJMError};
+use crate::{ljm::handle::{ConnectionType, DeviceHandleInfo, DeviceType}, LJMError};
 
 #[cfg(feature = "stream")]
 use crate::ljm::stream::LJMStream;

--- a/src/ljm/core.rs
+++ b/src/ljm/core.rs
@@ -10,7 +10,7 @@ use std::{fmt::Display, sync::RwLock};
 #[cfg(feature = "dynlink")]
 use libloading::{Library, Symbol};
 
-use crate::{ljm::handle::{ConnectionType, DeviceHandleInfo, DeviceType}, LJMError};
+use crate::{lib, ljm::handle::{ConnectionType, DeviceHandleInfo, DeviceType}, LJMError};
 
 #[cfg(feature = "stream")]
 use crate::ljm::stream::LJMStream;
@@ -182,17 +182,17 @@ impl LJMLibrary {
     /// Takes a handle to the labjack, the name to be written and the value to be written.
     /// Does not return a value.
     #[doc(alias = "LJM_eWriteName")]
-    pub fn write_name<T: Into<Vec<u8>>>(
+    pub fn write_name<T: Into<Vec<u8>>, V: Into<c_double>>(
         handle: i32,
         name_to_write: T,
-        value_to_write: u32,
+        value_to_write: V,
     ) -> Result<(), LJMError> {
         #[cfg(feature = "dynlink")]
         let d_write_to_addr: Symbol<extern "C" fn(i32, *const c_char, c_double) -> i32> =
             unsafe { LJMLibrary::get_c_function(b"LJM_eWriteName")? };
 
         let ntw = CString::new(name_to_write).expect("CString conversion failed");
-        let vtw = c_double::from(value_to_write);
+        let vtw = c_double::from(value_to_write.into());
 
         #[cfg(feature = "dynlink")]
         let error_code = d_write_to_addr(handle, ntw.as_ptr(), vtw);
@@ -618,13 +618,13 @@ impl LJMLibrary {
     /// Digitally writes an integer config
     /// Does not return a value
     #[doc(alias = "LJM_WriteLibraryConfigS")]
-    pub fn set_config(config_name: String, config_value: u32) -> Result<(), LJMError> {
+    pub fn set_config<V: Into<c_double>>(config_name: String, config_value: V) -> Result<(), LJMError> {
         #[cfg(feature = "dynlink")]
         let d_write_to_addr: Symbol<extern "C" fn(*const c_char, c_double) -> i32> =
             unsafe { LJMLibrary::get_c_function(b"LJM_WriteLibraryConfigS")? };
 
         let ntw = CString::new(config_name).expect("CString conversion failed");
-        let vtw = c_double::from(config_value);
+        let vtw = c_double::from(config_value.into());
 
         #[cfg(feature = "dynlink")]
         let error_code = d_write_to_addr(ntw.as_ptr(), vtw);


### PR DESCRIPTION
### Changes
- Allows `write_name` to take any `Into<c_double>` type (u32, f32, f64, ...)
- Allows the same behaviour for `set_config`
- Updates `write.rs` example to show this behaviour

Resolves #4 