### PR TITLE
mod: Use `scans_per_read` as array size, not `scan_rate`

### DIFF
--- a/src/ljm/core.rs
+++ b/src/ljm/core.rs
@@ -545,7 +545,7 @@ impl LJMLibrary {
 
             stream.replace(LJMStream {
                 scan_list: addresses,
-                scan_rate,
+                scans_per_read,
             });
         }
 
@@ -594,7 +594,7 @@ impl LJMLibrary {
         let mut ljm_scan_backlog: i32 = 0;
 
         // Length = ScansPerRead * NumberOfAddresses
-        let scan_length = stream_value.scan_rate as usize * stream_value.scan_list.len();
+        let scan_length = stream_value.scans_per_read as usize * stream_value.scan_list.len();
 
         let mut addr_slice = vec![0.0; scan_length];
 

--- a/src/ljm/stream.rs
+++ b/src/ljm/stream.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "stream")]
 pub struct LJMStream {
     // Stores the scan rate
-    pub(crate) scan_rate: f64,
+    pub(crate) scans_per_read: i32,
 
     // Stores a list of the internal LJM addresses
     pub(crate) scan_list: Vec<i32>,


### PR DESCRIPTION
Fix closes #6 